### PR TITLE
Fix lab result status handling and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Para rodar o projeto HipoZero na sua máquina local, siga estes passos:
     Crie um arquivo `.env` na raiz do projeto, copiando o arquivo `.env.example`. Você precisará das suas próprias chaves do Supabase.
 
     ```.env
-    VITE_SUPABASE_URL="[https://afyoidxrshkmplxhcyeh.supabase.co](https://afyoidxrshkmplxhcyeh.supabase.co)"
+    VITE_SUPABASE_URL="https://afyoidxrshkmplxhcyeh.supabase.co"
     VITE_SUPABASE_ANON_KEY="eyJhbGciOiJIZDI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFmeW9pZHhyc2hrbXBseGhjeWVoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MjMyMDQ0MjcsImV4cCI6MjAzODc4MDQyN30.jH9Z5L4i5v-4a4Co3Cn_l2sbQZ22Y2j23aJq3Tf2A2A"
     ```
     *(**Nota:** As chaves acima são do arquivo `.env.example`. Substitua pelas chaves reais do seu projeto Supabase.)*

--- a/src/lib/supabase/lab-results-queries.js
+++ b/src/lib/supabase/lab-results-queries.js
@@ -89,7 +89,7 @@ export async function createLabResult(labResult) {
     try {
         // Calcular status apenas se houver valores manuais
         let status = 'pending';
-        if (labResult.test_value) {
+        if (labResult.test_value !== null && labResult.test_value !== undefined && labResult.test_value !== '') {
             status = calculateStatus(
                 labResult.test_value,
                 labResult.reference_min,
@@ -126,8 +126,9 @@ export async function updateLabResult(labResultId, updates) {
 
         // Recalcular status apenas se houver valores manuais e mudaram
         const finalTestValue = updates.test_value !== undefined ? updates.test_value : current?.test_value;
+        const hasManualValue = finalTestValue !== null && finalTestValue !== undefined && finalTestValue !== '';
         const shouldRecalculateStatus =
-            finalTestValue &&
+            hasManualValue &&
             (updates.test_value !== undefined || updates.reference_min !== undefined || updates.reference_max !== undefined);
 
         if (shouldRecalculateStatus && current) {
@@ -136,7 +137,7 @@ export async function updateLabResult(labResultId, updates) {
                 updates.reference_min !== undefined ? updates.reference_min : current.reference_min,
                 updates.reference_max !== undefined ? updates.reference_max : current.reference_max
             );
-        } else if (!finalTestValue && updates.test_value === null) {
+        } else if (!hasManualValue && updates.test_value === null) {
             // Se removeu o test_value, setar status como pending
             updates.status = 'pending';
         }

--- a/src/lib/utils/anthropometry-calculations.js
+++ b/src/lib/utils/anthropometry-calculations.js
@@ -78,7 +78,7 @@ export function calculateBodyDensityWeltman(triceps, biceps, subscapular, suprai
 
 /**
  * Calcula densidade corporal usando protocolo selecionado
- * @param {object} skinfolds - Objeto com as dobras cutâneas
+ * @param {object} skinfolds - Objeto com as dobras cutâneas (ex.: subescapular, suprailiaca)
  * @param {number} age - Idade (anos)
  * @param {boolean} isMale - Gênero (true = masculino)
  * @param {string} protocol - Protocolo: 'pollock3', 'pollock7', 'weltman'
@@ -247,4 +247,3 @@ export function getSomatotypeDescription(endo, meso, ecto) {
     return 'Ectomorfo';
   }
 }
-


### PR DESCRIPTION
### Motivation

- Ensure lab result status is correctly recalculated when `test_value` is zero and set to `pending` when the value is cleared.
- Improve clarity of anthropometry utilities by documenting expected skinfold field names.
- Fix the `.env` example in the README so the Supabase URL is a plain string rather than a markdown link.

### Description

- Change `createLabResult` to only calculate status when `labResult.test_value` is not `null`, `undefined`, or an empty string by using an explicit check rather than a truthy check.
- In `updateLabResult`, compute `finalTestValue` and `hasManualValue` and use these to decide when to recalculate `status` and when to set `status = 'pending'` if the manual value was removed.
- Update `README.md` to use `VITE_SUPABASE_URL="https://afyoidxrshkmplxhcyeh.supabase.co"` in the `.env` example instead of a markdown link.
- Add clarification in `src/lib/utils/anthropometry-calculations.js` comment to show example skinfold keys (e.g., `subescapular`, `suprailiaca`).

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695409439b20832fa177be6ea4f55411)